### PR TITLE
First batch size fix

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -167,7 +167,7 @@ LogsProcessor.prototype.run = function(handler) {
         }
 
         // Get the first batch.
-        stream.next();
+        stream.next(nextLimit);
 
         // Process batch of logs.
         stream.on('data', function(data) {


### PR DESCRIPTION
logger didn't count batchSize for first one batch, it caused error for logging extensions, where max batch size is less than 100.