### PR TITLE
Using lodash method pickBy instead of filter inside the method getLogFilter of processor.js file.

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -32,7 +32,7 @@ LogsProcessor.prototype.getLogFilter = function(options) {
   if (options.logLevel) {
     types = types.concat(
       _.keys(
-        _.filter(logTypes, function(type) {
+        _.pickBy(logTypes, function(type) {
           return type.level >= options.logLevel;
         })
       )


### PR DESCRIPTION
Reason: _filter_ method return an array of objects and then _keys_
method obtains the indexes of array values. Because of this, the
subsequent query, which is send to Auth0 API Management, fails. _pickBy_
method returns and object with the filtered values and then _keys_
method return the Auth0 Log types and finally, the query works fine.