### PR TITLE
Cron route

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,47 @@ processor
   .then(status => console.log(status))
   .catch(err => console.log(err));
 ```
+
+## Route
+
+Prepared route for cron, requires `storage` and `options`
+
+ - `onLogsReceived`: function (logs, cb) - use to send logs somewhere
+ - `maxBatchSize`: Maximal batch size allowed
+ - `batchSize`: Size of the batch we'll make available in the handler
+ - `startFrom`: The Auth0 Log identifier to start from
+ - `logTypes`: An array of log types to filter on
+ - `logLevel`: The log level to filter on (0 = debug, 1 = info, 2 = warning, 3 = error, 4 = critical)
+ - `domain`: Auth0 Domain
+ - `clientId`: Auth0 Client Id
+ - `clientSecret`: Auth0 Client Secret
+ - `slackWebhook`: Slack Webhook Url
+ - `extensionName`: Extension Name for reports
+ - `extensionTitle`: Extension Title for reports
+ - `sendSuccess`: This setting will enable verbose notifications to Slack which are useful for troubleshooting
+
+```js
+const route = new Route(storage, {
+  domain: config('AUTH0_DOMAIN'),
+  clientId: config('AUTH0_CLIENT_ID'),
+  clientSecret: config('AUTH0_CLIENT_SECRET'),
+  batchSize: config('BATCH_SIZE'),
+  startFrom: config('START_FROM'),
+  logTypes: [ 'ss', 'fn' ],
+  logLevel: config('LOG_LEVEL'),
+  slackWebhook: config('SLACK_INCOMING_WEBHOOK_URL'),
+  extensionName: 'auth0-logs-to-somewhere',
+  extensionTitle: 'Logs To Somewhere Extension',
+  onLogsReceived: function(logs, cb) => {
+                    sendLogsSomewhere(function(err, result) {
+                      if (err) {
+                        return cb(err);
+                      }
+
+                      cb();
+                    });
+                  })
+});
+
+app.use(route);
+```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ Prepared route for cron, requires `storage` and `options`
  - `sendSuccess`: This setting will enable verbose notifications to Slack which are useful for troubleshooting
 
 ```js
-const route = new Route(storage, {
+const { Route } = require('auth0-log-extension-tools');
+
+app.use(Route(storage, {
   domain: config('AUTH0_DOMAIN'),
   clientId: config('AUTH0_CLIENT_ID'),
   clientSecret: config('AUTH0_CLIENT_SECRET'),
@@ -139,16 +141,14 @@ const route = new Route(storage, {
   slackWebhook: config('SLACK_INCOMING_WEBHOOK_URL'),
   extensionName: 'auth0-logs-to-somewhere',
   extensionTitle: 'Logs To Somewhere Extension',
-  onLogsReceived: function(logs, cb) => {
-                    sendLogsSomewhere(function(err, result) {
-                      if (err) {
-                        return cb(err);
-                      }
+  onLogsReceived: function(logs, cb) =>
+    sendLogsSomewhere(function(err, result) {
+      if (err) {
+        return cb(err);
+      }
 
-                      cb();
-                    });
-                  })
-});
-
-app.use(route);
+      cb();
+    })
+  })
+);
 ```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "auth0-extension-tools": "^1.2.1",
     "bluebird": "3.4.6",
     "lodash": "4.8.2",
+    "moment": "^2.22.1",
     "superagent": "1.2.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ module.exports.LogsApiStream = require('./stream');
 
 module.exports.logTypes = require('./logTypes');
 
+module.exports.Route = require('./route');
+
 module.exports.reporters = {
   SlackReporter: SlackReporter
 };

--- a/src/route.js
+++ b/src/route.js
@@ -1,0 +1,107 @@
+const moment = require('moment');
+const tools = require('auth0-extension-tools');
+
+const loggingTools = require('./index');
+
+function Route(storage, options) {
+  if (!storage) {
+    throw new tools.ArgumentError('Must provide a storage object');
+  }
+
+  if (!options) {
+    throw new tools.ArgumentError('Must provide an options object');
+  }
+
+  if (typeof options.onLogsReceived !== 'function') {
+    throw new tools.ArgumentError('Must provide options.onLogsReceived function');
+  }
+
+  return function(req, res, next) {
+    const wtBody = (req.webtaskContext && req.webtaskContext.body) || req.body || {};
+    const wtHead = (req.webtaskContext && req.webtaskContext.headers) || {};
+    const isCron = (wtBody.schedule && wtBody.state === 'active') || (wtHead.referer === 'https://manage.auth0.com/' && wtHead['if-none-match']);
+
+    if (!isCron) {
+      return next();
+    }
+
+    const onLogsReceived = options.onLogsReceived;
+    const maxBatchSize = options.maxBatchSize || 100;
+
+    const slack = new loggingTools.reporters.SlackReporter({
+      hook: options.slackWebhook,
+      username: options.extensionName || 'auth0-logging-extension',
+      title: options.extensionTitle || 'Auth0 Logging Extension'
+    });
+
+    const loggerOpts = {
+      domain: options.domain,
+      clientId: options.clientId,
+      clientSecret: options.clientSecret,
+      batchSize: parseInt(options.batchSize, 10),
+      startFrom: options.startFrom,
+      logTypes: options.logTypes,
+      logLevel: options.logLevel
+    };
+
+
+    if (!loggerOpts.batchSize || loggerOpts.batchSize > maxBatchSize) {
+      loggerOpts.batchSize = maxBatchSize;
+    }
+
+    if (loggerOpts.logTypes && !Array.isArray(loggerOpts.logTypes)) {
+      loggerOpts.logTypes = loggerOpts.logTypes.replace(/\s/g, '').split(',');
+    }
+
+    const auth0logger = new loggingTools.LogsProcessor(storage, loggerOpts);
+
+    const sendDailyReport = function(lastReportDate) {
+      const current = new Date();
+
+      const end = current.getTime();
+      const start = end - 86400000;
+      return auth0logger.getReport(start, end)
+        .then(function(report) {
+          return slack.send(report, report.checkpoint);
+        })
+        .then(function() {
+          return storage.read();
+        })
+        .then(function(data) {
+          data.lastReportDate = lastReportDate;
+          return storage.write(data);
+        });
+    };
+
+    const checkReportTime = function() {
+      return storage.read()
+        .then(function(data) {
+          const now = moment().format('DD-MM-YYYY');
+          const reportTime = options.reportTime || 16;
+
+          if (data.lastReportDate !== now && new Date().getHours() >= reportTime) {
+            sendDailyReport(now);
+          }
+        });
+    };
+
+    return auth0logger
+      .run(onLogsReceived)
+      .then(function(result) {
+        if (result && result.status && result.status.error) {
+          slack.send(result.status, result.checkpoint);
+        } else if (options.sendSuccess === true || options.sendSuccess === 'true') {
+          slack.send(result.status, result.checkpoint);
+        }
+        checkReportTime();
+        return res.json(result);
+      })
+      .catch(function(err) {
+        slack.send({ error: err, logsProcessed: 0 }, null);
+        checkReportTime();
+        return next(err);
+      });
+  };
+}
+
+module.exports = Route;


### PR DESCRIPTION
As differences between log-extensions route are too few, we can move route to the log-tools. It will allow us to simplify log-extensions even more.

Tested on `logs-to-cloudwatch`