### PR TITLE
Retry api2 requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-log-extension-tools",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A set of tools for logging",
   "main": "src/index.js",
   "dependencies": {

--- a/src/processor.js
+++ b/src/processor.js
@@ -10,6 +10,7 @@ function LogsProcessor(storageContext, options) {
     throw new tools.ArgumentError('Must provide an options object');
   }
 
+  this.start = new Date().getTime();
   this.storage = new StorageProvider(storageContext);
   this.options = _.assign({ },
     {
@@ -100,7 +101,9 @@ LogsProcessor.prototype.createStream = function(options) {
       return new LogsApiStream({
         checkpointId: startCheckpoint,
         types: self.getLogFilter(options),
+        start: self.start,
         maxRetries: options.maxRetries,
+        maxRunTimeSeconds: options.maxRunTimeSeconds,
         domain: options.domain,
         clientId: options.clientId,
         clientSecret: options.clientSecret,
@@ -112,7 +115,7 @@ LogsProcessor.prototype.createStream = function(options) {
 LogsProcessor.prototype.run = function(handler) {
   const self = this;
   return new Promise(function(resolve, reject) {
-    const start = new Date().getTime();
+    const start = self.start;
     var retries = 0;
     var lastLogDate = 0;
     var logsBatch = [];

--- a/src/processor.js
+++ b/src/processor.js
@@ -15,7 +15,7 @@ function LogsProcessor(storageContext, options) {
     {
       batchSize: 100,
       maxRetries: 5,
-      maxRunTimeSeconds: 20
+      maxRunTimeSeconds: 40
     },
     options
   );
@@ -100,6 +100,7 @@ LogsProcessor.prototype.createStream = function(options) {
       return new LogsApiStream({
         checkpointId: startCheckpoint,
         types: self.getLogFilter(options),
+        maxRetries: options.maxRetries,
         domain: options.domain,
         clientId: options.clientId,
         clientSecret: options.clientSecret,

--- a/src/processor.js
+++ b/src/processor.js
@@ -16,7 +16,7 @@ function LogsProcessor(storageContext, options) {
     {
       batchSize: 100,
       maxRetries: 5,
-      maxRunTimeSeconds: 20
+      maxRunTimeSeconds: 28
     },
     options
   );

--- a/src/processor.js
+++ b/src/processor.js
@@ -15,7 +15,7 @@ function LogsProcessor(storageContext, options) {
     {
       batchSize: 100,
       maxRetries: 5,
-      maxRunTimeSeconds: 40
+      maxRunTimeSeconds: 20
     },
     options
   );

--- a/src/stream.js
+++ b/src/stream.js
@@ -85,7 +85,12 @@ LogsApiStream.prototype.next = function(take) {
           return logs;
         })
         .catch(function(err) {
-          if (self.options.maxRetries > self.retries) {
+          const start = self.options.start;
+          const limit = self.options.maxRunTimeSeconds;
+          const now = new Date().getTime();
+          const hasTime = start + (limit * 1000) >= now;
+
+          if (self.options.maxRetries > self.retries && hasTime) {
             self.retries++;
             return getLogs();
           }

--- a/tests/helpers/mocks.js
+++ b/tests/helpers/mocks.js
@@ -13,6 +13,7 @@ module.exports.logs = (options = {}) =>
    })
   .get('/api/v2/logs')
   .query(() => true)
+  .delay(options.delay || 0)
   .times(options.times || 1)
   .reply(function(uri) {
     if (options.error) {

--- a/tests/lib/stream.tests.js
+++ b/tests/lib/stream.tests.js
@@ -10,7 +10,7 @@ const createStream = (filters) => {
     types: filters,
     start: new Date().getTime(),
     maxRetries: 2,
-    maxRunTimeSeconds: 5,
+    maxRunTimeSeconds: 1,
     domain: 'foo.auth0.local',
     clientId: '1',
     clientSecret: 'secret',
@@ -130,10 +130,8 @@ describe('LogsApiStream', () => {
       logger.next();
     });
 
-    it('should emit error if no time left', function(done) {
-      this.timeout(6000);
-
-      helpers.mocks.logs({ error: 'time is up', delay: 5000 });
+    it('should emit error if no time left', (done) => {
+      helpers.mocks.logs({ error: 'time is up', delay: 1000 });
 
       const logger = createStream();
       logger.on('data', () => logger.next());


### PR DESCRIPTION
✏️ Changes
This PR is adding retry functionality for api2 (`/logs`) requests. It use `maxRetries` option, value is 5 by default.

🔗 References
Slack conversation: https://auth0.slack.com/archives/C9170558S/p1528229562000006
Jira: https://auth0team.atlassian.net/browse/KEY-137

🎯 Testing
✅ This has been tested locally
✅ This has been tested in a webtask
✅ Unit test were added for this change

🖥 Appliance
✅ This change is compatible with the appliance.