### PR TITLE
Log error message from failed send attempts

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -209,7 +209,7 @@ LogsProcessor.prototype.run = function(handler) {
       ];
 
       if (options.logger) {
-        options.logger.error(error[0], error[1]);
+        options.logger.error(error[0] && error[0].message || error[0], error[1]);
       }
 
       // We're giving up.


### PR DESCRIPTION
## ✏️ Changes
  
Currently, logs show the following which is not helpful in identifying a problem with the log export.

```checkpoint: 90020190628032144798656085170094219032655730256692379730
start: 2019-06-28T03:21:51.914Z
end: 2019-06-28T03:21:57.119Z
logsProcessed: 0
error: [{"cause":{},"isOperational":true},"Skipping logs from 90020190628031540443551250646802263919691376682789240930 to 90020190628032144798656085170094219032655730256692379730 after 5 retries."]
```
  
## 🔗 References
  
[ESD-1050: SumoLogic logging extension fails exporting for unknown reason](https://auth0team.atlassian.net/projects/ESD/queues/custom/409/ESD-1050)
  
## 🎯 Testing
   
🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
N/A
  
✅ This can be deployed any time

